### PR TITLE
Rename Row YY to Section Y on the map page

### DIFF
--- a/src/Pages/Map/Map.js
+++ b/src/Pages/Map/Map.js
@@ -288,7 +288,7 @@ class Map extends React.Component {
                 </div>
               </div>
               <div id="section-YY" onClick={this.state.width < 7000? () => {this.selectSection('YY');}: () => {}}>
-                    <Row sectionID="YY" isOnline={true} fileSource="https://docs.google.com/spreadsheets/d/e/2PACX-1vSOSJ5ebiSq4oLtvHKceSPf9WRxRDeDIzs8cGCm23AjLiq8LrTIUjocEX0RgioBr2leg7E5p_SWVJPH/pub?gid=1851413578&single=true&output=csv" addToNamesList={this.addToNamesList} selectedSection={this.state.selectedSection} selectedId={this.state.selectedId} setIsLoading={this.setIsLoading}/>
+                    <Row sectionID="YY" displayTitle="Section Y" isOnline={true} fileSource="https://docs.google.com/spreadsheets/d/e/2PACX-1vSOSJ5ebiSq4oLtvHKceSPf9WRxRDeDIzs8cGCm23AjLiq8LrTIUjocEX0RgioBr2leg7E5p_SWVJPH/pub?gid=1851413578&single=true&output=csv" addToNamesList={this.addToNamesList} selectedSection={this.state.selectedSection} selectedId={this.state.selectedId} setIsLoading={this.setIsLoading}/>
               </div>
             </div>
             <div>

--- a/src/components/Map/Row.js
+++ b/src/components/Map/Row.js
@@ -110,7 +110,7 @@ class Row extends Component {
     render = () => {
         return (
             <div className="blockWrapper">
-                <p className="blockTitle">Row {this.props.sectionID}</p>
+                <p className="blockTitle">{this.props.displayTitle || `Row ${this.props.sectionID}`}</p>
                 <div>
                     {(this.state.width < 7000 && this.props.selectedSection != this.props.sectionID) || this.state.data.length == 0? 
                         ((this.props.selectedId.slice(0, this.props.sectionID.length) === this.props.sectionID)?  <div className="rowBlankSelected"> Tap to see exact location</div>: <div className="rowBlank"></div>): 


### PR DESCRIPTION
## Summary
- Add optional `displayTitle` prop to Row component for custom section labels
- Change "Row YY" to display as "Section Y" on the map page
- Maintains backward compatibility - other rows are unaffected

## Test plan
- [x] Verified change locally with `npm start`
- [ ] Confirm "Section Y" displays correctly on the map page
- [ ] Verify other rows still show their original labels