### PR TITLE
Add instant.page for link prefetching on hover

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,5 +43,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <!-- Prefetch pages on hover for instant navigation -->
+    <script src="https://instant.page/5.2.0" type="module" integrity="sha384-jnZyxPjiipYXnSU0ber8UYWa/3y0MNbEfrhMLCKM7LbKZe+rHb7oydnHx6pIYCXD"></script>
   </body>
 </html>


### PR DESCRIPTION
Prefetches pages when users hover over links for 65ms, making navigation feel instant. Works with existing localStorage caching for faster Map page loads.